### PR TITLE
#11 - fix websocket request origin

### DIFF
--- a/lib/routes.go
+++ b/lib/routes.go
@@ -14,7 +14,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var upgrader = websocket.Upgrader{}
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
 
 func rootHandle(w http.ResponseWriter, r *http.Request) {
 	tpl := template.Must(template.ParseGlob(TEMPLATEPATH))


### PR DESCRIPTION
A proper fix for a more built-out site would look something like this:

```go
# ...
CheckOrigin: func(r *http.Request) bool {
	// Replace these origins with your allowed origins
	allowedOrigins := []string{"https://example.com", "https://subdomain.example.com"}
	origin := r.Header.Get("Origin")
	for _, allowedOrigin := range allowedOrigins {
		if allowedOrigin == origin {
			return true
		}
	}
	return false
},
}
# ...
```

but for now this works!